### PR TITLE
Use helper to create redux action handlers

### DIFF
--- a/template/src/modules/helpers.ts
+++ b/template/src/modules/helpers.ts
@@ -1,6 +1,6 @@
 import produce from 'immer';
 import { map } from 'ramda';
-import { createAction, createReducer } from '@reduxjs/toolkit';
+import { createAction, createReducer, PayloadActionCreator } from '@reduxjs/toolkit';
 
 export interface ReduxAction<T> {
   type: string;
@@ -15,4 +15,13 @@ export const actionCreator = (prefix: string) => <T>(actionName: string) =>
 export const createImmutableReducer = <T>(initialState: T, reducers: { [key: string]: Reducer<T> }) => {
   // @ts-ignore
   return createReducer(initialState, map(produce, reducers));
+};
+
+export const actionHandler = <P, S>(
+  action: PayloadActionCreator<P>,
+  handler: (state: S, action: ReduxAction<P>) => void
+) => {
+  return {
+    [action.toString()]: handler,
+  };
 };

--- a/template/src/modules/locales/locales.redux.ts
+++ b/template/src/modules/locales/locales.redux.ts
@@ -1,4 +1,4 @@
-import { createImmutableReducer, ReduxAction } from '../helpers';
+import { actionHandler, createImmutableReducer, ReduxAction } from '../helpers';
 import { localesActions } from '.';
 
 export type LocalesState = {
@@ -14,7 +14,7 @@ const handleSetLanguage = (state: LocalesState, { payload }: ReduxAction<string>
 };
 
 const HANDLERS = {
-  [localesActions.setLanguage.toString()]: handleSetLanguage,
+  ...actionHandler(localesActions.setLanguage, handleSetLanguage),
 };
 
 export const reducer = createImmutableReducer(INITIAL_STATE, HANDLERS);

--- a/template/src/modules/users/users.redux.ts
+++ b/template/src/modules/users/users.redux.ts
@@ -1,4 +1,4 @@
-import { createImmutableReducer, ReduxAction } from '../helpers';
+import { actionHandler, createImmutableReducer, ReduxAction } from '../helpers';
 import { usersActions } from '.';
 
 export interface User {
@@ -25,8 +25,8 @@ const handleFetchUsersSuccess = (state: UsersState, { payload: users }: ReduxAct
 };
 
 const HANDLERS = {
-  [usersActions.fetchUsers.toString()]: handleFetchUsers,
-  [usersActions.fetchUsersSuccess.toString()]: handleFetchUsersSuccess,
+  ...actionHandler(usersActions.fetchUsers, handleFetchUsers),
+  ...actionHandler(usersActions.fetchUsersSuccess, handleFetchUsersSuccess),
 };
 
 export const reducer = createImmutableReducer(INITIAL_STATE, HANDLERS);


### PR DESCRIPTION
Main benefit of this change is (apart from requiring to use `toString()` explicitly) that it guards the type of action handler payload based on the action it receives.

The helper will only accept reducer which accepts payload with same type as the action it reacts to.