### PR TITLE
Use immer implicitly in reducers

### DIFF
--- a/template/plop/reduxModule/templates/redux.hbs
+++ b/template/plop/reduxModule/templates/redux.hbs
@@ -1,4 +1,5 @@
-import { createImmutableReducer, ReduxAction } from '../helpers';
+import { createReducer } from '@reduxjs/toolkit';
+import { ReduxAction, actionHandler } from '../helpers';
 import { {{ camelCase name }}Actions } from '.';
 
 export interface {{ pascalCase name }}State {
@@ -18,8 +19,8 @@ const handleFetch{{ pascalCase name }}Success = (state: {{ pascalCase name }}Sta
 };
 
 const HANDLERS = {
-  [{{ camelCase name }}Actions.fetch{{ pascalCase name }}.toString()]: handleFetch{{ pascalCase name }},
-  [{{ camelCase name }}Actions.fetch{{ pascalCase name }}Success.toString()]: handleFetch{{ pascalCase name }}Success,
+  ...actionHandler({{ camelCase name }}Actions.fetch{{ pascalCase name }}, handleFetch{{ pascalCase name }}),
+  ...actionHandler({{ camelCase name }}Actions.fetch{{ pascalCase name }}Success, handleFetch{{ pascalCase name }}Success),
 };
 
-export const reducer = createImmutableReducer(INITIAL_STATE, HANDLERS);
+export const reducer = createReducer(INITIAL_STATE, HANDLERS);

--- a/template/src/modules/helpers.ts
+++ b/template/src/modules/helpers.ts
@@ -1,21 +1,12 @@
-import produce from 'immer';
-import { map } from 'ramda';
-import { createAction, createReducer, PayloadActionCreator } from '@reduxjs/toolkit';
+import { createAction, PayloadActionCreator } from '@reduxjs/toolkit';
 
 export interface ReduxAction<T> {
   type: string;
   payload: T;
 }
 
-export type Reducer<T> = (currentState: T, action: ReduxAction<any>) => void;
-
 export const actionCreator = (prefix: string) => <T>(actionName: string) =>
   createAction<T>([prefix, actionName].join('/'));
-
-export const createImmutableReducer = <T>(initialState: T, reducers: { [key: string]: Reducer<T> }) => {
-  // @ts-ignore
-  return createReducer(initialState, map(produce, reducers));
-};
 
 export const actionHandler = <P, S>(
   action: PayloadActionCreator<P>,

--- a/template/src/modules/locales/locales.redux.ts
+++ b/template/src/modules/locales/locales.redux.ts
@@ -1,4 +1,5 @@
-import { actionHandler, createImmutableReducer, ReduxAction } from '../helpers';
+import { createReducer } from '@reduxjs/toolkit';
+import { actionHandler, ReduxAction } from '../helpers';
 import { localesActions } from '.';
 
 export type LocalesState = {
@@ -17,4 +18,4 @@ const HANDLERS = {
   ...actionHandler(localesActions.setLanguage, handleSetLanguage),
 };
 
-export const reducer = createImmutableReducer(INITIAL_STATE, HANDLERS);
+export const reducer = createReducer(INITIAL_STATE, HANDLERS);

--- a/template/src/modules/startup/startup.redux.ts
+++ b/template/src/modules/startup/startup.redux.ts
@@ -1,7 +1,7 @@
-import { createImmutableReducer } from '../helpers';
+import { createReducer } from '@reduxjs/toolkit';
 
 export type StartupState = {};
 
 export const INITIAL_STATE: StartupState = {};
 
-export const reducer = createImmutableReducer(INITIAL_STATE, {});
+export const reducer = createReducer(INITIAL_STATE, {});

--- a/template/src/modules/users/users.redux.ts
+++ b/template/src/modules/users/users.redux.ts
@@ -1,4 +1,5 @@
-import { actionHandler, createImmutableReducer, ReduxAction } from '../helpers';
+import { createReducer } from '@reduxjs/toolkit';
+import { actionHandler, ReduxAction } from '../helpers';
 import { usersActions } from '.';
 
 export interface User {
@@ -29,4 +30,4 @@ const HANDLERS = {
   ...actionHandler(usersActions.fetchUsersSuccess, handleFetchUsersSuccess),
 };
 
-export const reducer = createImmutableReducer(INITIAL_STATE, HANDLERS);
+export const reducer = createReducer(INITIAL_STATE, HANDLERS);


### PR DESCRIPTION
redux-toolkit reducers use immer implicitly so there is no need to wrap reducers with immer manually (https://redux-toolkit.js.org/api/createReducer)