### PR TITLE
[#33] Simple handler for promise saga consumer

### DIFF
--- a/template/src/@types/redux-saga.d.ts
+++ b/template/src/@types/redux-saga.d.ts
@@ -35,5 +35,5 @@ declare module 'redux-saga/effects' {
   export const takeLeading: EffectHandlerBinding;
   export const takeLatest: EffectHandlerBinding;
   export const takeEvery: EffectHandlerBinding;
-  export const take: EffectHandlerBinding;
+  export const take: (actionCreator: PayloadActionCreator<P>) => any;
 }

--- a/template/src/modules/helpers.ts
+++ b/template/src/modules/helpers.ts
@@ -1,9 +1,19 @@
 import { createAction, PayloadActionCreator } from '@reduxjs/toolkit';
+import { ActionPromise } from '../shared/utils/actionPromise/actions';
 
 export interface ReduxAction<T> {
   type: string;
   payload: T;
 }
+
+export const actionPromiseCreator = (prefix: string) => <P = void, O = P>(actionName: string) =>
+  createActionPromise<P, O>([prefix, actionName].join('/'));
+
+export const createActionPromise = <P, O>(name: string): ActionPromise<P, O> => ({
+  trigger: createAction<P>([name, 'TRIGGER'].join('/')),
+  success: createAction<O>([name, 'SUCCESS'].join('/')),
+  error: createAction<any>([name, 'ERROR'].join('/')),
+});
 
 export const actionCreator = (prefix: string) => <T>(actionName: string) =>
   createAction<T>([prefix, actionName].join('/'));

--- a/template/src/modules/sagas.ts
+++ b/template/src/modules/sagas.ts
@@ -2,12 +2,14 @@ import { all, fork } from 'redux-saga/effects';
 
 import { watchStartup } from './startup/startup.sagas';
 import { watchUsers } from './users/users.sagas';
+import promiseWatcher from '../shared/utils/actionPromise/sagaWatcher';
 //<-- IMPORT MODULE SAGA -->
 
 export default function* rootSaga() {
   yield all([
     fork(watchStartup),
     fork(watchUsers),
+    fork(promiseWatcher),
     //<-- INJECT MODULE SAGA -->
   ]);
 }

--- a/template/src/modules/users/__tests__/users.sagas.spec.ts
+++ b/template/src/modules/users/__tests__/users.sagas.spec.ts
@@ -13,8 +13,8 @@ describe('Users: sagas', () => {
 
     await expectSaga(watchUsers)
       .withState(defaultState)
-      .put(usersActions.fetchUsersSuccess(usersMock))
-      .dispatch(usersActions.fetchUsers())
+      .put(usersActions.fetchUsers.success(usersMock))
+      .dispatch(usersActions.fetchUsers.trigger)
       .silentRun();
   });
 });

--- a/template/src/modules/users/users.actions.ts
+++ b/template/src/modules/users/users.actions.ts
@@ -1,7 +1,5 @@
-import { actionCreator } from '../helpers';
+import { actionPromiseCreator } from '../helpers';
 import { User } from './users.redux';
 
-const createAction = actionCreator('USERS');
-
-export const fetchUsers = createAction<void>('FETCH_USERS');
-export const fetchUsersSuccess = createAction<User[]>('FETCH_USERS_SUCCESS');
+const createAction = actionPromiseCreator('USERS');
+export const fetchUsers = createAction<void, User[]>('FETCH_USERS');

--- a/template/src/modules/users/users.redux.ts
+++ b/template/src/modules/users/users.redux.ts
@@ -26,8 +26,8 @@ const handleFetchUsersSuccess = (state: UsersState, { payload: users }: ReduxAct
 };
 
 const HANDLERS = {
-  ...actionHandler(usersActions.fetchUsers, handleFetchUsers),
-  ...actionHandler(usersActions.fetchUsersSuccess, handleFetchUsersSuccess),
+  ...actionHandler(usersActions.fetchUsers.trigger, handleFetchUsers),
+  ...actionHandler(usersActions.fetchUsers.success, handleFetchUsersSuccess),
 };
 
 export const reducer = createReducer(INITIAL_STATE, HANDLERS);

--- a/template/src/modules/users/users.sagas.ts
+++ b/template/src/modules/users/users.sagas.ts
@@ -9,12 +9,13 @@ export const USERS_URL = '/users';
 function* fetchUsers() {
   try {
     const { data } = yield api.get(USERS_URL);
-    yield put(usersActions.fetchUsersSuccess(data));
+    yield put(usersActions.fetchUsers.success(data));
   } catch (error) {
+    yield put(usersActions.fetchUsers.error(error.message));
     reportError(error);
   }
 }
 
 export function* watchUsers() {
-  yield all([takeLatest(usersActions.fetchUsers, fetchUsers)]);
+  yield all([takeLatest(usersActions.fetchUsers.trigger, fetchUsers)]);
 }

--- a/template/src/shared/components/users/useUsers.hook.ts
+++ b/template/src/shared/components/users/useUsers.hook.ts
@@ -1,12 +1,26 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
 import { usersActions, usersSelectors } from '../../../modules/users';
 import { User } from '../../../modules/users/users.redux';
+import { usePromiseDispatch } from '../../hooks/usePromiseDispatch';
 
-export const useUsers = (): [User[], () => void] => {
-  const dispatch = useDispatch();
+export const useUsers = (): [{ users: User[]; isFetching: boolean }, { fetchUsers: () => Promise<void> }] => {
+  const [isFetching, setFetching] = useState(false);
 
   const users = useSelector(usersSelectors.selectUsers);
-  const fetchUsers = () => dispatch(usersActions.fetchUsers());
+  const fetchUsers = usePromiseDispatch(usersActions.fetchUsers);
 
-  return [users, fetchUsers];
+  return [
+    { users, isFetching },
+    {
+      fetchUsers: async () => {
+        setFetching(true);
+        try {
+          await fetchUsers();
+        } finally {
+          setFetching(false);
+        }
+      },
+    },
+  ];
 };

--- a/template/src/shared/components/users/users.component.tsx
+++ b/template/src/shared/components/users/users.component.tsx
@@ -7,12 +7,12 @@ import { Button } from '../button';
 import { useUsers } from './useUsers.hook';
 
 export const UsersComponent: FC = () => {
-  const [users, fetchUsers] = useUsers();
+  const [{ users, isFetching }, { fetchUsers }] = useUsers();
 
   return (
     <Container>
       <Button onClick={fetchUsers}>
-        <FormattedMessage {...messages.fetchUsers} />
+        <FormattedMessage {...(isFetching ? messages.fetching : messages.fetchUsers)} />
       </Button>
 
       <ul>

--- a/template/src/shared/components/users/users.messages.ts
+++ b/template/src/shared/components/users/users.messages.ts
@@ -6,4 +6,8 @@ export default defineMessages({
     id: 'users.fetchUsers',
     defaultMessage: 'Fetch users',
   },
+  fetching: {
+    id: 'users.fetching',
+    defaultMessage: 'Fetching...',
+  },
 });

--- a/template/src/shared/hooks/usePromiseDispatch/__tests__/usePromiseDispatch.hook.spec.ts
+++ b/template/src/shared/hooks/usePromiseDispatch/__tests__/usePromiseDispatch.hook.spec.ts
@@ -1,0 +1,31 @@
+import { useDispatch } from 'react-redux';
+import { renderHook } from '@testing-library/react-hooks';
+import { usePromiseDispatch } from '../usePromiseDispatch.hook';
+import { createActionPromise } from '../../../../modules/helpers';
+import { PROMISE_REQUEST } from '../../../utils/actionPromise/actions';
+
+jest.mock('react-redux');
+
+describe('usePromiseDispatch: Hook', () => {
+  const dispatch = jest.fn();
+  beforeEach(() => {
+    useDispatch.mockReturnValue(dispatch);
+  });
+
+  it('should dispatch promisifed version of the action', () => {
+    const action = createActionPromise<object, object>('TEST');
+    const { result } = renderHook(() => usePromiseDispatch(action));
+    const MOCK_DATA = { foo: 'bar' };
+    result.current(MOCK_DATA);
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: PROMISE_REQUEST,
+      payload: {
+        payload: MOCK_DATA,
+        promiseDefinition: action,
+        resolve: expect.any(Function),
+        reject: expect.any(Function),
+      },
+    });
+  });
+});

--- a/template/src/shared/hooks/usePromiseDispatch/index.ts
+++ b/template/src/shared/hooks/usePromiseDispatch/index.ts
@@ -1,0 +1,1 @@
+export { usePromiseDispatch } from './usePromiseDispatch.hook';

--- a/template/src/shared/hooks/usePromiseDispatch/usePromiseDispatch.hook.ts
+++ b/template/src/shared/hooks/usePromiseDispatch/usePromiseDispatch.hook.ts
@@ -1,0 +1,20 @@
+import { useDispatch } from 'react-redux';
+import { ActionPromise, promiseRequest } from '../../utils/actionPromise/actions';
+
+type PromiseDispatcher<P, O> = (payload: P) => Promise<O>;
+
+export const usePromiseDispatch = <P, O>(action: ActionPromise<P, O>): PromiseDispatcher<P, O> => {
+  const dispatch = useDispatch();
+
+  return (payload: P) =>
+    new Promise((resolve, reject) => {
+      dispatch(
+        promiseRequest({
+          promiseDefinition: action,
+          payload,
+          resolve,
+          reject,
+        })
+      );
+    });
+};

--- a/template/src/shared/utils/actionPromise/__tests__/sagaWatcher.spec.ts
+++ b/template/src/shared/utils/actionPromise/__tests__/sagaWatcher.spec.ts
@@ -1,0 +1,58 @@
+import { expectSaga } from 'redux-saga-test-plan';
+
+import watchPromise from '../sagaWatcher';
+import { createActionPromise } from '../../../../modules/helpers';
+import { promiseRequest } from '../actions';
+
+const prepareTestAction = () => {
+  const action = createActionPromise<any, any>('TEST');
+  const payload = { foo: 'bar' };
+  const resolve = jest.fn();
+  const reject = jest.fn();
+
+  const promiseAction = promiseRequest({
+    promiseDefinition: action,
+    payload,
+    resolve,
+    reject,
+  });
+
+  return { promiseAction, action, payload, resolve, reject };
+};
+
+describe('Users: sagas', () => {
+  it('should dispatch trigger action with proper payload', async () => {
+    const { payload, promiseAction, action } = prepareTestAction();
+
+    await expectSaga(watchPromise)
+      .put(action.trigger(payload))
+      .dispatch(promiseAction)
+      .silentRun();
+  });
+
+  it('should resolve promise if success was dispatched', async () => {
+    const { reject, resolve, promiseAction, action } = prepareTestAction();
+    const resultData = { a: 'data' };
+
+    await expectSaga(watchPromise)
+      .dispatch(promiseAction)
+      .dispatch(action.success(resultData))
+      .silentRun();
+
+    expect(resolve).toHaveBeenCalledWith(resultData);
+    expect(reject).not.toHaveBeenCalledWith();
+  });
+
+  it('should reject promise if error was dispatched', async () => {
+    const { reject, resolve, promiseAction, action } = prepareTestAction();
+    const errorData = { a: 'data' };
+
+    await expectSaga(watchPromise)
+      .dispatch(promiseAction)
+      .dispatch(action.error(errorData))
+      .silentRun();
+
+    expect(reject).toHaveBeenCalledWith(errorData);
+    expect(resolve).not.toHaveBeenCalledWith();
+  });
+});

--- a/template/src/shared/utils/actionPromise/actions.ts
+++ b/template/src/shared/utils/actionPromise/actions.ts
@@ -1,0 +1,20 @@
+import { createAction, PayloadActionCreator } from '@reduxjs/toolkit';
+
+export interface ActionPromise<P, O> {
+  trigger: PayloadActionCreator<P>;
+  success: PayloadActionCreator<O>;
+  error: PayloadActionCreator<any>;
+}
+
+export interface ActionPromiseRequest<P, O> {
+  promiseDefinition: ActionPromise<P, O>;
+  payload: P;
+  resolve: (data: O) => void;
+  reject: (error: any) => void;
+}
+
+export const PROMISE_REQUEST = '__META__/PROMISE_REQUEST';
+export const promiseRequestAction = createAction<ActionPromiseRequest<any, any>>(PROMISE_REQUEST);
+export const promiseRequest = <P, O>(actionPromiseData: ActionPromiseRequest<P, O>) => {
+  return promiseRequestAction(actionPromiseData);
+};

--- a/template/src/shared/utils/actionPromise/sagaWatcher.ts
+++ b/template/src/shared/utils/actionPromise/sagaWatcher.ts
@@ -1,0 +1,25 @@
+import { all, call, put, race, take, takeEvery } from 'redux-saga/effects';
+import { ActionPromiseRequest, promiseRequestAction } from './actions';
+import { ReduxAction } from '../../../modules/helpers';
+
+export function* handleRoutinePromiseAction({ payload: actionData }: ReduxAction<ActionPromiseRequest<any, any>>) {
+  const { promiseDefinition, reject, resolve, payload } = actionData;
+
+  const [{ success, error }] = yield all([
+    race({
+      success: take(promiseDefinition.success),
+      error: take(promiseDefinition.error),
+    }),
+    put(promiseDefinition.trigger(payload)),
+  ]);
+
+  if (success) {
+    yield call(resolve, success?.payload);
+  } else {
+    yield call(reject, error?.payload);
+  }
+}
+
+export default function* routinePromiseWatcherSaga() {
+  yield takeEvery(promiseRequestAction, handleRoutinePromiseAction);
+}


### PR DESCRIPTION
#33

None of existing solutions for promisifying sagas seems to fit our stack - it should be compatible with redux-toolkit creators and it should be strongly typed.
I feel like this case is frequent enough in our project to be handled in the boilerplate.

So I implemented a simple solution (based on redux-saga-routines API)
- wrapper that creates a `routine` actions with trigger & success & error stages
- `usePromiseDispatch()` consumer that dispatches action wrapped with metadata requred to invoke promise lifecycle callbacks
- saga watcher that consumes those actions and can invoke resolve/reject callbacks for consumer