### PR TITLE
Don't use FC<...> prop typing

### DIFF
--- a/template/plop/reactComponent/templates/component.hbs
+++ b/template/plop/reactComponent/templates/component.hbs
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 
 import { Container } from './{{ camelCase name }}.styles';
 
@@ -6,7 +6,7 @@ export interface {{ pascalCase name }}ComponentProps {
   children?: ReactNode;
 }
 
-export const {{ pascalCase name }}Component: FC<{{ pascalCase name }}ComponentProps> = ({ children }) => {
+export const {{ pascalCase name }}Component = ({ children }: {{ pascalCase name }}ComponentProps) => {
   return (
     <Container>
       <h1>{{ pascalCase name }} component</h1>

--- a/template/src/routes/app.component.tsx
+++ b/template/src/routes/app.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, Fragment, ReactNode } from 'react';
+import React, { Fragment, ReactNode } from 'react';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import { IntlProvider, FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';
@@ -16,7 +16,7 @@ export interface AppComponentProps {
   children?: ReactNode;
 }
 
-export const AppComponent: FC<AppComponentProps> = ({ children }) => {
+export const AppComponent = ({ children }: AppComponentProps) => {
   useStartup();
   useLanguageFromParams();
 

--- a/template/src/shared/components/button/button.component.tsx
+++ b/template/src/shared/components/button/button.component.tsx
@@ -1,4 +1,4 @@
-import React, { ButtonHTMLAttributes, FC } from 'react';
+import React, { ButtonHTMLAttributes } from 'react';
 import { DefaultTheme, ThemeProvider } from 'styled-components';
 import { empty } from 'ramda';
 
@@ -14,14 +14,14 @@ export interface ButtonTheme extends DefaultTheme {
   disabled: boolean;
 }
 
-export const ButtonComponent: FC<ButtonComponentProps> = ({
+export const ButtonComponent = ({
   children,
   className,
   mode = ButtonType.PRIMARY,
   onClick = empty,
   disabled,
   ...other
-}) => (
+}: ButtonComponentProps) => (
   <ThemeProvider theme={{ mode, disabled } as ButtonTheme}>
     <Container onClick={onClick} className={className} disabled={disabled} {...other}>
       {children}

--- a/template/src/shared/components/hiddenOnPlatform/hiddenOnPlatform.component.tsx
+++ b/template/src/shared/components/hiddenOnPlatform/hiddenOnPlatform.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React from 'react';
 import { Breakpoint } from '../../../theme/media';
 import { useMediaQuery } from '../../hooks/useMediaQuery';
 
@@ -16,7 +16,7 @@ export interface HiddenOnPlatformComponentProps {
  * <HiddenOnPlatform matches={Breakpoint.DESKTOP}>...</HiddenOnPlatform> - will not render children for desktop
  * <HiddenOnPlatform matches={[Breakpoint.DESKTOP, Breakpoint.MOBILE]}>...</HiddenOnPlatform> - will not render children for desktop & mobile
  **/
-export const HiddenOnPlatformComponent: FC<HiddenOnPlatformComponentProps> = ({ children, below, above, matches }) => {
+export const HiddenOnPlatformComponent = ({ children, below, above, matches }: HiddenOnPlatformComponentProps) => {
   const { matches: shouldHide } = useMediaQuery({ above, below, matches });
   return shouldHide ? null : <>{children}</>;
 };

--- a/template/src/shared/components/responsiveThemeProvider/responsiveThemeProvider.component.tsx
+++ b/template/src/shared/components/responsiveThemeProvider/responsiveThemeProvider.component.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { useState } from 'react';
 import { DefaultTheme, ThemeProvider } from 'styled-components';
 import responsiveTheme from '../../../theme/responsiveTheme';
 import { useWindowListener } from '../../hooks/useWindowListener';
@@ -10,7 +10,7 @@ export interface ResponsiveThemeProviderProps {
   children: React.ReactNode;
 }
 
-export const ResponsiveThemeProvider: FC<ResponsiveThemeProviderProps> = ({ theme: themeDefinition, children }) => {
+export const ResponsiveThemeProvider = ({ theme: themeDefinition, children }: ResponsiveThemeProviderProps) => {
   const [theme, setTheme] = useState(parseTheme(themeDefinition));
   const handleResize = () => setTheme(parseTheme(themeDefinition));
   useWindowListener('resize', handleResize, { throttle: 200 });

--- a/template/src/shared/utils/testUtils.tsx
+++ b/template/src/shared/utils/testUtils.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, ReactElement, FC } from 'react';
+import React, { ReactNode, ReactElement } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { render } from '@testing-library/react';
 import { createStore } from 'redux';
@@ -54,7 +54,7 @@ interface ProvidersWrapperProps {
   context: ContextData;
 }
 
-export const ProvidersWrapper: FC<ProvidersWrapperProps> = ({ children, context = {} }) => {
+export const ProvidersWrapper = ({ children, context = {} }: ProvidersWrapperProps) => {
   const { router = {}, store = fixturesStore, messages, theme = defaultTheme } = context;
   const { url = `/${DEFAULT_LOCALE}`, routePath = '/:lang/', history } = router;
 


### PR DESCRIPTION
Turns out that using React.FC doesn't really give much benefits, while having one (pretty significant in my opinion) flaw - it adds `children` prop implicitly even if you don't expect it in your component.

That makes it possible to accept unwanted children without compile error like below.

```
const Component: React.FC = () => { /*... */ };
const Example = () => {
	<Component>Unwanted children</App>
}
```

Instead we can just use explicit TS prop types