### PR TITLE
Cast FormattedMessage value to string

### DIFF
--- a/template/src/routes/app.component.tsx
+++ b/template/src/routes/app.component.tsx
@@ -32,7 +32,7 @@ export const AppComponent = ({ children }: AppComponentProps) => {
         <ThemeProvider theme={theme}>
           <Fragment>
             <FormattedMessage {...messages.pageTitle}>
-              {pageTitle => <Helmet titleTemplate={`%s - ${pageTitle}`} defaultTitle={pageTitle} />}
+              {(pageTitle: string) => <Helmet titleTemplate={`%s - ${pageTitle}`} defaultTitle={pageTitle} />}
             </FormattedMessage>
 
             <GlobalStyle />


### PR DESCRIPTION
Fix failing tests by manually casting formatted message to string (potentially it could also be ReactNode for rich formatted input)